### PR TITLE
Decouple tract scoring helpers from session state

### DIFF
--- a/secondharvestmap.py
+++ b/secondharvestmap.py
@@ -1,319 +1,373 @@
+"""Geographic needs assessment dashboard for census tracts."""
+
+from __future__ import annotations
+
 import streamlit as st
-import pandas as pd
-import plotly.express as px
 
 from map_utils import make_map
 from utils import (
+    initialize_session_config,
     load_config,
-    get_missing_defaults,
     load_and_process_data,
     post_process_data,
+    update_session_config,
 )
 
 
-def update_config(config, **kwargs):
-    for k, v in kwargs.items():
-        config[k] = v
-    return config
+def _render_help_popover() -> None:
+    """Render the help popover that describes how to use the dashboard."""
 
+    info, title, *_ = st.columns([0.1, 2], gap="small", vertical_alignment="bottom")
+    title.title("Census Tract Analysis")
 
-if "config" not in st.session_state:
-    st.session_state["config"] = load_config()
-    get_missing_defaults(st.session_state["config"])
-    st.session_state.df = pd.DataFrame()
+    with info.popover("", icon=":material/question_mark:", use_container_width=False):
+        tab_instructions, tab_roadmap = st.tabs(["Using the Map", "Roadmap"])
+        with tab_instructions:
+            columns = st.columns(2)
+            columns[0].markdown(
+                """
+                #### Weights
+                Use the sliders in the sidebar to adjust how much each factor matters
+                in the calculation. This lets you focus on specific concerns or
+                balance all factors equally. The weights are normalised to sum to 1.0
+                before the calculation.
 
-config = st.session_state["config"]
-updated_marker_opacity = config["client_marker"]["opacity"]
-updated_marker_size = config["client_marker"]["size"]
-fixed_client_marker_color = "#1f77b4"
-st.session_state["map_type"] = config.get("map_type", "Scatter Map")
+                - **Food Insecurity Weight**: Controls the influence of food insecurity
+                  rates.
+                - **Poverty Weight**: Controls the influence of poverty rates.
+                - **Vehicle Access Weight**: Controls the influence of lacking vehicle
+                  access.
 
+                #### Normalise Scores
+                When enabled, this option equalises the range of each factor before
+                combining them. This prevents factors with naturally larger ranges
+                from dominating the calculation.
 
-# Set Wide Mode
-st.set_page_config(layout="wide")
-info, title, *x = st.columns([0.1, 2], gap="small", vertical_alignment="bottom")
-title.title("Census Tract Analysis")
+                #### Access to a Vehicle
+                Choose between measuring households with no vehicles or those with
+                fewer vehicles than members.
+                """
+            )
+            columns[1].markdown(
+                """
+                #### Program Markers
+                - **Toggle visibility** by selecting items in the legend.
+                - **Adjust appearance** in the Map Details sidebar.
 
-with info.popover("", icon=":material/question_mark:", use_container_width=False):
-    tab1, roadmap = st.tabs(["Using the Map", "Roadmap"])
-    with tab1:
-        cols = st.columns(2)
-        cols[0].markdown("""
-        #### Weights  
-        Use the sliders in the sidebar to adjust how much each factor matters in the calculation. This lets you focus on specific concerns or balance all factors equally.
-        Note that the weights are normalized to add up to 1.0 before the calculation.
-        
-        - **Food Insecurity Weight**: Affects the impact of food insecurity rates in the combined score
-        - **Poverty Weight**: Affects the impact of poverty rates in the combined score
-        - **Vehicle Access Weight**: Affects the impact of lacking vehicle access in the combined score
-        
-        #### Normalize Scores
-        When enabled, this option equalizes the range of each factor before combining them. This prevents factors with naturally larger numeric ranges from dominating the calculation.
-                    
-        #### Access to a Vehicle
-        You can choose to measure:
-        - Households with no vehicles (default)
-        - Households with fewer vehicles than members
-        """)
-        cols[1].markdown("""                
-        #### Program Markers
-        - **Toggle visibility**: Click on items in the legend to show/hide specific program types
-        - **Adjust appearance**: Control marker size and opacity in the Map Details sidebar
-        
-        #### Color Scale
-        Adjusting the color scale maximum value can help highlight differences between areas more effectively. A lower maximum makes moderate-need areas more visually distinct.
-        
-        #### Map Opacity
-        Controls how transparent the census tract colors appear on the map. 
-        """)
-    with roadmap:
-        done, todo = st.columns([1, 1])
-        done.header("Completed")
-        done.checkbox("Initial Calculation and Display", value=True, disabled=True)
-        done.checkbox("Map Interactivity", value=True, disabled=True)
-        done.checkbox("~~STOP REFRESHING~~ Performance fix", value=True, disabled=True)
-        done.checkbox("Label county seats", value=True, disabled=True)
-        done.checkbox("Address Upload", value=True, disabled=True)
-        done.checkbox("~~JUST LOAD FASTER~~ Performance fix", value=True, disabled=True)
-        done.checkbox("Investigate missing tracts", value=True, disabled=True)
-        done.checkbox("Download geocoded addresses", value=True, disabled=True)
-        done.checkbox("Program Overlay", value=True, disabled=True)
-        done.checkbox("Faster Geocoder", value=True, disabled=True)
-        todo.header("TODO")
-        todo.checkbox("Public Transit Overlay", value=False, disabled=True)
-        todo.checkbox("Program Impact Overlay", value=False, disabled=True)
+                #### Colour Scale
+                Adjust the colour scale maximum to highlight differences between areas.
 
-with st.sidebar:
-    with st.expander("Address Overlay", icon=":material/home:"):
-       
-        st.header("Upload Addresses")
-        st.markdown(
-            "Upload a file containing addresses or coordinates to overlay them on the map."
-        )
-        st.session_state["client_coordinates"] = st.file_uploader(
-            "Upload CSV/Excel file",
-            type=["csv", "txt", "xlsx"],
-            help="File must have either lat/lon columns or Address, Address Line 2, City, Zip fields",
-        )
-        if "df" in st.session_state and not st.session_state.df.empty:
-            df = st.session_state.df
-            programs = set(df["Program Type"].dropna().unique().tolist()) - {"Client"}
-        else:
-            df = pd.DataFrame()
-            programs = set()
-
-        if programs:
-            available_programs = sorted(programs)
-            current_filters = config.get("program_filters", [])
-            default_selection = [
-                prog for prog in current_filters if prog in available_programs
-            ]
-            if default_selection != current_filters:
-                config = update_config(config, program_filters=default_selection)
-                st.session_state["config"] = config
-                current_filters = default_selection
-
-            selected_programs = st.multiselect(
-                "Filter Program Types",
-                options=available_programs,
-                default=current_filters,
-                help=(
-                    "Select program types to display on the map. "
-                    "Leave empty to show every uploaded program."
-                ),
+                #### Map Opacity
+                Controls how transparent the census tract colours appear on the map.
+                """
             )
 
-            if selected_programs != current_filters:
-                config = update_config(config, program_filters=selected_programs)
-                st.session_state["config"] = config
-        elif config.get("program_filters"):
-            config = update_config(config, program_filters=[])
-            st.session_state["config"] = config
+        with tab_roadmap:
+            done, todo = st.columns([1, 1])
+            done.header("Completed")
+            for label in [
+                "Initial Calculation and Display",
+                "Map Interactivity",
+                "~~STOP REFRESHING~~ Performance fix",
+                "Label county seats",
+                "Address Upload",
+                "~~JUST LOAD FASTER~~ Performance fix",
+                "Investigate missing tracts",
+                "Download geocoded addresses",
+                "Program Overlay",
+                "Faster Geocoder",
+            ]:
+                done.checkbox(label, value=True, disabled=True)
+
+            todo.header("TODO")
+            todo.checkbox("Public Transit Overlay", value=False, disabled=True)
+            todo.checkbox("Program Impact Overlay", value=False, disabled=True)
 
 
+def _handle_program_filters(config: dict) -> None:
+    """Persist the program filter selections to session state."""
 
-        if not df.empty:
-            # Download df as two files, one with rows with lat/lon and one with ones we couldn't geocode
-            lat_lon_df = df.dropna(subset=["lat", "lon"])
-            no_geo_df = df[df["lat"].isnull() | df["lon"].isnull()]
-            lat_lon_csv = lat_lon_df.to_csv(index=False)
-            no_geo_csv = no_geo_df[
-                [c for c in no_geo_df.columns if c not in ["lat", "lon"]]
-            ].to_csv(index=False)
-            with st.popover("Export", icon=":material/download:"):
-                button_cols = st.columns(2)
-                with button_cols[0]:
-                    st.download_button(
-                        label="Mapped Addresses",
-                        data=lat_lon_csv,
-                        file_name="geocoded_addresses.csv",
-                        mime="text/csv",
-                    )
-                with button_cols[1]:
-                    st.download_button(
-                        label="Failed Addresses",
-                        data=no_geo_csv,
-                        file_name="addresses_geocoder_failed_on.csv",
-                        mime="text/csv",
-                        disabled=no_geo_df.empty,
-                    )
-    with st.expander("Calculation Controls", expanded=True, icon=":material/tune:"):
-        slider_config = config["sliders"]["weight"]
+    if "df" not in st.session_state or st.session_state.df.empty:
+        if config.get("program_filters"):
+            update_session_config(program_filters=[])
+        return
 
-        sliders = st.container()
-        st.session_state["config"]["normalize"] = sliders.checkbox(
-            "Normalize Variables",
-            value=config.get("normalize", True),
-            help="Turn this off to use raw scores opposed to relative scores.",
-        )
-        sliders.write("### Factor Weights")
-        sliders.caption("Adjust how each factor influences the combined score.")
-        food_weight = sliders.slider(
-            "Food Insecurity Weight",
-            slider_config["min"],
-            slider_config["max"],
-            config.get("food_weight", 1.0),
-            step=slider_config["step"],
-            key="fw",
-            help="The weight of food insecurity in the calculation.",
-        )
-        poverty_weight = sliders.slider(
-            "Poverty Weight",
-            slider_config["min"],
-            slider_config["max"],
-            config.get("poverty_weight", 1.0),
-            step=slider_config["step"],
-            key="pw",
-            help="The weight of poverty in the calculation.",
-        )
-        vehicle_weight = sliders.slider(
-            "Vehicle Access Weight",
-            slider_config["min"],
-            slider_config["max"],
-            config.get("vehicle_weight", 0.33),
-            step=slider_config["step"],
-            key="vw",
-            help="The weight of not having a vehicle in the calculation.",
-        )
-        vehicle_num_toggle = st.checkbox(
-            "Include Households with Fewer Vehicles than Members",
-            key="vnt",
-            value=config.get("vehicle_num_toggle", False),
-        )
+    dataframe = st.session_state.df
+    programs = set(dataframe["Program Type"].dropna().unique().tolist()) - {"Client"}
+    if not programs:
+        if config.get("program_filters"):
+            update_session_config(program_filters=[])
+        return
 
-    with st.expander("Display Controls", icon=":material/palette:"):
-        scale_config = config["sliders"]["scale_max"]
-        st.write("### Map Color Scale")
-        if config["scale_max"] == "auto":
-            default_scale_max = float(
-                st.session_state["tracts"].combined_pct.quantile(0.90)
+    available_programs = sorted(programs)
+    current_filters = config.get("program_filters", [])
+    default_selection = [program for program in current_filters if program in available_programs]
+
+    if default_selection != current_filters:
+        update_session_config(program_filters=default_selection)
+        current_filters = default_selection
+
+    selected_programs = st.multiselect(
+        "Filter Program Types",
+        options=available_programs,
+        default=current_filters,
+        help="Select program types to display on the map. Leave empty to show every uploaded program.",
+    )
+
+    if selected_programs != current_filters:
+        update_session_config(program_filters=selected_programs)
+
+
+def _render_address_overlay(config: dict) -> None:
+    """Render the address overlay section of the sidebar."""
+
+    st.header("Upload Addresses")
+    st.markdown("Upload a file containing addresses or coordinates to overlay them on the map.")
+    st.session_state["client_coordinates"] = st.file_uploader(
+        "Upload CSV/Excel file",
+        type=["csv", "txt", "xlsx"],
+        help="File must have either lat/lon columns or Address, Address Line 2, City, Zip fields",
+    )
+
+    _handle_program_filters(config)
+
+    if "df" not in st.session_state or st.session_state.df.empty:
+        return
+
+    dataframe = st.session_state.df
+    lat_lon_df = dataframe.dropna(subset=["lat", "lon"])
+    no_geo_df = dataframe[dataframe["lat"].isnull() | dataframe["lon"].isnull()]
+
+    lat_lon_csv = lat_lon_df.to_csv(index=False)
+    no_geo_csv = no_geo_df[[column for column in no_geo_df.columns if column not in ["lat", "lon"]]].to_csv(index=False)
+
+    with st.popover("Export", icon=":material/download:"):
+        button_columns = st.columns(2)
+        with button_columns[0]:
+            st.download_button(
+                label="Mapped Addresses",
+                data=lat_lon_csv,
+                file_name="geocoded_addresses.csv",
+                mime="text/csv",
             )
-        else:
-            default_scale_max = (
-                float(config["scale_max"])
-                if isinstance(config["scale_max"], (int, float))
-                else float(config["scale_max"][0])
+        with button_columns[1]:
+            st.download_button(
+                label="Failed Addresses",
+                data=no_geo_csv,
+                file_name="addresses_geocoder_failed_on.csv",
+                mime="text/csv",
+                disabled=no_geo_df.empty,
             )
 
-        scale_max = st.slider(
-            "Color Scale Max",
-            min_value=float(scale_config["min"]),
-            max_value=float(scale_config["max"]),
-            value=default_scale_max,
-            step=float(scale_config["step"]),
-            key="sm",
-            help="Adjust to make differences between areas more visible",
-        )
-        opacity_config = config["sliders"]["map_opacity"]
-        map_opacity = st.slider(
-            "Map Opacity",
-            opacity_config["min"],
-            opacity_config["max"],
-            config["map_display"]["opacity"],
-            step=opacity_config["step"],
-            key="mo",
-        )
-        config["map_display"]["opacity"] = map_opacity
 
-        st.write("### Client Markers")
-        marker_config = config["sliders"]["marker_size"]
-        updated_marker_opacity = st.slider(
-            "Marker Opacity",
-            0.1,
-            1.0,
-            config["client_marker"]["opacity"],
-            step=0.05,
-            key="mop",
-        )
-        updated_marker_size = st.slider(
-            "Marker Size",
-            marker_config["min"],
-            marker_config["max"],
-            config["client_marker"]["size"],
-            step=marker_config["step"],
-        )
-        updated_marker_color = st.color_picker(
-            "Marker Color", fixed_client_marker_color
-        )
+def _render_calculation_controls(config: dict) -> tuple[bool, bool, float, float, float]:
+    """Render sliders that configure the combined score calculation."""
 
-        st.write("### Program Markers")
-        st.caption("Adjust the appearance of program markers on the map.")
-        program_marker_opacity = st.slider(
-            "Program Marker Opacity",
-            0.1,
-            1.0,
-            config["program_marker"]["opacity"],
-            step=0.05,
-            key="pmo",
-        )
-        program_marker_size = st.slider(
+    slider_config = config["sliders"]["weight"]
+    sliders = st.container()
+
+    should_normalise = sliders.checkbox(
+        "Normalise Variables",
+        value=config.get("normalize", True),
+        help="Turn this off to use raw scores instead of relative scores.",
+    )
+
+    sliders.write("### Factor Weights")
+    sliders.caption("Adjust how each factor influences the combined score.")
+
+    food_weight = sliders.slider(
+        "Food Insecurity Weight",
+        slider_config["min"],
+        slider_config["max"],
+        config.get("food_weight", 1.0),
+        step=slider_config["step"],
+        key="fw",
+        help="The weight of food insecurity in the calculation.",
+    )
+    poverty_weight = sliders.slider(
+        "Poverty Weight",
+        slider_config["min"],
+        slider_config["max"],
+        config.get("poverty_weight", 1.0),
+        step=slider_config["step"],
+        key="pw",
+        help="The weight of poverty in the calculation.",
+    )
+    vehicle_weight = sliders.slider(
+        "Vehicle Access Weight",
+        slider_config["min"],
+        slider_config["max"],
+        config.get("vehicle_weight", 0.33),
+        step=slider_config["step"],
+        key="vw",
+        help="The weight of not having a vehicle in the calculation.",
+    )
+    vehicle_num_toggle = st.checkbox(
+        "Include Households with Fewer Vehicles than Members",
+        key="vnt",
+        value=config.get("vehicle_num_toggle", False),
+    )
+
+    update_session_config(
+        {
+            "normalize": should_normalise,
+            "food_weight": food_weight,
+            "poverty_weight": poverty_weight,
+            "vehicle_weight": vehicle_weight,
+            "vehicle_num_toggle": vehicle_num_toggle,
+        }
+    )
+
+    return should_normalise, vehicle_num_toggle, poverty_weight, vehicle_weight, food_weight
+
+
+def _render_display_controls(config: dict) -> None:
+    """Render controls that affect how the map is displayed."""
+
+    st.write("### Map Colour Scale")
+    scale_config = config["sliders"]["scale_max"]
+    if config["scale_max"] == "auto":
+        default_scale_max = float(st.session_state["tracts"].combined_pct.quantile(0.90))
+    else:
+        raw_value = config["scale_max"]
+        default_scale_max = float(raw_value if isinstance(raw_value, (int, float)) else raw_value[0])
+
+    scale_max = st.slider(
+        "Colour Scale Max",
+        min_value=float(scale_config["min"]),
+        max_value=float(scale_config["max"]),
+        value=default_scale_max,
+        step=float(scale_config["step"]),
+        key="sm",
+        help="Adjust to make differences between areas more visible",
+    )
+
+    opacity_config = config["sliders"]["map_opacity"]
+    map_opacity = st.slider(
+        "Map Opacity",
+        opacity_config["min"],
+        opacity_config["max"],
+        config["map_display"]["opacity"],
+        step=opacity_config["step"],
+        key="mo",
+    )
+
+    st.write("### Client Markers")
+    marker_config = config["sliders"]["marker_size"]
+    marker_opacity = st.slider(
+        "Marker Opacity",
+        0.1,
+        1.0,
+        config["client_marker"]["opacity"],
+        step=0.05,
+        key="mop",
+    )
+    marker_size = st.slider(
+        "Marker Size",
+        marker_config["min"],
+        marker_config["max"],
+        config["client_marker"]["size"],
+        step=marker_config["step"],
+    )
+    marker_colour = st.color_picker(
+        "Marker Colour",
+        config["client_marker"].get("color", "#1f77b4"),
+    )
+
+    st.write("### Program Markers")
+    st.caption("Adjust the appearance of program markers on the map.")
+    program_marker_opacity = st.slider(
+        "Program Marker Opacity",
+        0.1,
+        1.0,
+        config["program_marker"]["opacity"],
+        step=0.05,
+        key="pmo",
+    )
+    program_marker_size = st.slider(
         "Program Marker Size",
         config["sliders"]["marker_size"]["min"],
         config["sliders"]["marker_size"]["max"],
         config["program_marker"]["size"],
         step=1,
         key="pms",
-        )
-        
-        config = update_config(
-            config,
-            scale_max=scale_max,
-            map_opacity=map_opacity,
-            program_marker={
-                "opacity": program_marker_opacity,
-                "size": program_marker_size,
-            },
-        )
-        st.session_state["config"] = config
-if "tracts" not in st.session_state:
-    st.session_state["tracts"] = load_and_process_data(config)
+    )
 
-config = update_config(
-    config,
-    client_marker={
-        "size": updated_marker_size,
-        "color": updated_marker_color,
-        "opacity": updated_marker_opacity,
-    },
-    poverty_weight=poverty_weight,
-    food_weight=food_weight,
-    vehicle_weight=vehicle_weight,
-    vehicle_num_toggle=vehicle_num_toggle,
-    show_settings=False,
-    map_type=st.session_state["map_type"],
-)
-st.session_state["config"] = config
+    updated_map_display = dict(config["map_display"], opacity=map_opacity)
+    updated_client_marker = dict(
+        config["client_marker"],
+        size=marker_size,
+        opacity=marker_opacity,
+        color=marker_colour,
+    )
+    updated_program_marker = dict(
+        config["program_marker"],
+        opacity=program_marker_opacity,
+        size=program_marker_size,
+    )
 
-st.session_state["tracts"] = post_process_data(
-    st.session_state["tracts"],
-    vehicle_num_toggle,
-    poverty_weight,
-    vehicle_weight,
-    food_weight,
-)
-try:
-    fig = make_map(st.session_state["tracts"], "combined_pct", config)
-    st.plotly_chart(fig, use_container_width=True)
-except Exception as e:
-    st.error(f"Error processing data: {str(e)}")
-    raise
+    update_session_config(
+        {
+            "scale_max": scale_max,
+            "map_display": updated_map_display,
+            "client_marker": updated_client_marker,
+            "program_marker": updated_program_marker,
+        }
+    )
+
+
+def _render_sidebar(config: dict) -> tuple[bool, bool, float, float, float]:
+    with st.sidebar:
+        with st.expander("Address Overlay", icon=":material/home:"):
+            _render_address_overlay(config)
+
+        with st.expander("Calculation Controls", expanded=True, icon=":material/tune:"):
+            should_normalise, vehicle_num_toggle, poverty_weight, vehicle_weight, food_weight = _render_calculation_controls(config)
+
+        with st.expander("Display Controls", icon=":material/palette:"):
+            _render_display_controls(config)
+
+    return should_normalise, vehicle_num_toggle, poverty_weight, vehicle_weight, food_weight
+
+
+def _ensure_tracts_loaded(config: dict) -> None:
+    if "tracts" not in st.session_state:
+        st.session_state["tracts"] = load_and_process_data(config)
+
+
+def _update_map_data(normalize: bool, vehicle_num_toggle: bool, poverty_weight: float, vehicle_weight: float, food_weight: float) -> None:
+    st.session_state["tracts"] = post_process_data(
+        st.session_state["tracts"],
+        vehicle_num_toggle=vehicle_num_toggle,
+        poverty_weight=poverty_weight,
+        vehicle_weight=vehicle_weight,
+        food_weight=food_weight,
+        normalize=normalize,
+    )
+
+
+def main() -> None:
+    """Application entry point."""
+
+    st.set_page_config(layout="wide")
+    config_defaults = load_config()
+    config = initialize_session_config(config_defaults)
+    st.session_state.setdefault("map_type", config.get("map_type", "Scatter Map"))
+
+    _render_help_popover()
+    _ensure_tracts_loaded(config)
+
+    should_normalise, vehicle_num_toggle, poverty_weight, vehicle_weight, food_weight = _render_sidebar(config)
+    _update_map_data(should_normalise, vehicle_num_toggle, poverty_weight, vehicle_weight, food_weight)
+
+    try:
+        figure = make_map(st.session_state["tracts"], "combined_pct", config)
+        st.plotly_chart(figure, use_container_width=True)
+    except Exception as error:  # pragma: no cover - surfaced to the user
+        st.error(f"Error processing data: {error}")
+        raise
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,111 @@
+import pandas as pd
+import geopandas as gpd
+import pytest
+import streamlit as st
+
+from shapely.geometry import Point
+
+from utils import (
+    initialize_session_config,
+    merge_config_defaults,
+    normalize_column,
+    post_process_data,
+    update_session_config,
+)
+
+
+def setup_function():
+    """Reset Streamlit session state before each test."""
+
+    st.session_state.clear()
+
+
+def test_merge_config_defaults_handles_nested_dicts():
+    target = {"a": {"b": 1}, "c": 3}
+    defaults = {"a": {"b": 2, "d": 4}, "e": 5}
+
+    merge_config_defaults(target, defaults)
+
+    assert target["a"]["b"] == 1  # existing values are preserved
+    assert target["a"]["d"] == 4
+    assert target["e"] == 5
+
+
+def test_update_session_config_requires_initialisation():
+    with pytest.raises(RuntimeError):
+        update_session_config({"scale_max": 10})
+
+
+def test_normalize_column_returns_zero_for_constant_series():
+    column = pd.Series([5, 5, 5], dtype="float64")
+
+    result = normalize_column(column, enable=True)
+
+    assert result.eq(0).all()
+
+
+def test_normalize_column_passthrough_when_disabled():
+    column = pd.Series([1, 2, 3], dtype="float64")
+
+    result = normalize_column(column, enable=False)
+
+    pd.testing.assert_series_equal(result, column)
+
+
+def _make_sample_tracts() -> gpd.GeoDataFrame:
+    data = {
+        "pct_poverty": [10.0, 20.0, 30.0],
+        "pct_no_vehicle": [5.0, 10.0, 15.0],
+        "pct_fewer_vehicles": [3.0, 6.0, 9.0],
+        "pct_food_insecure": [0.0, 50.0, 100.0],
+    }
+    geometry = [Point(x, x) for x in range(len(next(iter(data.values()))))]
+    return gpd.GeoDataFrame(data, geometry=geometry)
+
+
+def test_post_process_data_respects_normalize_flag():
+    tracts = _make_sample_tracts()
+
+    raw = post_process_data(
+        tracts,
+        vehicle_num_toggle=False,
+        poverty_weight=1.0,
+        vehicle_weight=1.0,
+        food_weight=1.0,
+        normalize=False,
+    )
+    assert raw["pct_poverty"].tolist() == [10.0, 20.0, 30.0]
+
+    normalised = post_process_data(
+        tracts,
+        vehicle_num_toggle=False,
+        poverty_weight=1.0,
+        vehicle_weight=1.0,
+        food_weight=1.0,
+        normalize=True,
+    )
+    assert normalised["pct_poverty"].tolist() == [0.0, 50.0, 100.0]
+
+
+def test_post_process_data_vehicle_toggle_selects_correct_column():
+    tracts = _make_sample_tracts()
+
+    fewer_vehicle_result = post_process_data(
+        tracts,
+        vehicle_num_toggle=True,
+        poverty_weight=1.0,
+        vehicle_weight=1.0,
+        food_weight=1.0,
+        normalize=False,
+    )
+    assert fewer_vehicle_result["pct_vehicle"].tolist() == [3.0, 6.0, 9.0]
+
+    no_vehicle_result = post_process_data(
+        tracts,
+        vehicle_num_toggle=False,
+        poverty_weight=1.0,
+        vehicle_weight=1.0,
+        food_weight=1.0,
+        normalize=False,
+    )
+    assert no_vehicle_result["pct_vehicle"].tolist() == [5.0, 10.0, 15.0]


### PR DESCRIPTION
## Summary
- pass the normalisation toggle through the sidebar to the scoring helpers instead of reading Streamlit session state implicitly
- update the tract post-processing pipeline to accept explicit parameters and exercise the behaviour with new unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fd87e26df08332b1e758c217f469da